### PR TITLE
Add a file type plugin

### DIFF
--- a/ftdetect/mpdv.vim
+++ b/ftdetect/mpdv.vim
@@ -1,0 +1,5 @@
+"|---------------------------------------------------------------------------
+"| file type plugin to detects our .mpdv type
+"|---------------------------------------------------------------------------
+autocmd BufRead,BufNewFile *.mpdv   set filetype=mpdv
+

--- a/ftplugin/mpdv.vim
+++ b/ftplugin/mpdv.vim
@@ -1,0 +1,17 @@
+function! GetMpcStatusline()
+    let cmd = "mpc status"
+    let result = split(system(cmd), '\n')
+    let status = len(result) == 3 ? result[2] : result[0]
+    let [s:count, s:settings] = 
+    \ [len(split(system('mpc playlist'), '\n')), 
+    \ split(status, '   ')]
+    let s:statusline = " "
+    \ . s:settings[1] . " --- " 
+    \ . s:settings[2] . " ---%=" 
+    \ . s:count . " songs "
+    return s:statusline
+endfunction
+
+set buftype=nofile
+set statusline=%!GetMpcStatusline() 
+


### PR DESCRIPTION
Here we add a file type plugin to complement the functions implemented in our main plugin. The file
type plugin implements a status line that is displayed by vim when a file with the extension .mpdv
is opened or created.